### PR TITLE
Nesting thunk action creators

### DIFF
--- a/src/useThunkReducer.js
+++ b/src/useThunkReducer.js
@@ -1,11 +1,13 @@
-import { useReducer } from "react";
+import { useReducer, useRef } from "react";
 
 function useThunkReducer(reducer, initialState) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const thunk_dispatch_ref = useRef();
 
   const thunkDispatch = action =>
-    typeof action === "function" ? action(dispatch, state) : dispatch(action);
-
+    typeof action === "function" ? action(thunk_dispatch_ref.current, state) : dispatch(action);
+  thunk_dispatch_ref.current = thunkDispatch;
+  
   return [state, thunkDispatch];
 }
 


### PR DESCRIPTION
If one ```ActionCreator``` calls another ```ActionCreator``` demanding thunk, we should not pass original ```dispatch```